### PR TITLE
Escaped assets output for lotus 0.4.x

### DIFF
--- a/lib/lotus/assets/helpers.rb
+++ b/lib/lotus/assets/helpers.rb
@@ -1,15 +1,23 @@
 require 'lotus/assets/helpers/asset_tags'
+require 'lotus/utils/escape'
 
 module Lotus
   module Assets
     module Helpers
       def javascript(*sources)
-        AssetTags.render(:javascript, *sources)
+        _asset_raw(AssetTags.render(:javascript, *sources))
       end
 
       def stylesheet(*sources)
-        AssetTags.render(:stylesheet, *sources)
+        _asset_raw(AssetTags.render(:stylesheet, *sources))
       end
+
+      private
+
+      def _asset_raw(string)
+        ::Lotus::Utils::Escape::SafeString.new(string)
+      end
+
     end
   end
 end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+describe Lotus::Assets::Helpers do
+
+  def safe_string_class
+    ::Lotus::Utils::Escape::SafeString
+  end
+
+  describe '#javascript' do
+    before do
+      @javascript = View.new.javascript('feature-a')
+    end
+
+    it 'returns an instance of SafeString' do
+      @javascript.must_be_instance_of safe_string_class
+    end
+  end
+
+  describe '#stylesheet' do
+    before do
+      @stylesheet = View.new.stylesheet('main')
+    end
+
+    it 'returns an instance of SafeString' do
+      @stylesheet.must_be_instance_of safe_string_class
+    end
+  end
+end
+


### PR DESCRIPTION
By default lotus 0.4 is escaping any string on view. 

This commit allows lotus-assets to render HTML js/css tags properly.