### PR TITLE
Updated README with lotus usage instructions and running tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ View.new.render # => HTML markup
 For advanced configurations, please have a look at
 [`Lotus::Assets::Configuration`](https://github.com/lotus/assets/blob/master/lib/lotus/assets/configuration.rb).
 
+### Lotus usage
+For usage on `lotus` follow the instructions:
+
+- In your `apps/web/application.rb` include `lotus-assets` files:
+```ruby
+require 'lotus/assets'
+require 'lotus/assets/helpers'
+```
+
+- In your `application_layout` just include the assets helpers
+```ruby
+module Web
+  module Views
+    class ApplicationLayout
+      include Admin::Layout
+      include Lotus::Assets::Helpers
+    end
+  end
+end
+```
+
+- After that you will be able to use `javascript` and `stylesheet` in your template.
+
 ### Development mode
 
 `Lotus::Assets` can help you during the development process of your application.
@@ -216,6 +239,15 @@ public/
 └── assets
     ├── reset.css
     └── main.css
+```
+
+## Running tests
+
+- Make sure you have one of [ExecJS](https://github.com/rails/execjs)
+supported runtime on your machine.
+
+```sh
+bundle exec rake test
 ```
 
 ## Versioning


### PR DESCRIPTION
I had some troubles to use `lotus-assets` on `lotus` framework. 

This PR updates the README to help new users to use `sass` on `lotus`.

I also had problem running tests because I didn't have `nodejs` installed on my machine. Here is the stacktrace to help users to find how to solve it.

```
/home/wjsantos/.rvm/gems/ruby-2.2.1/gems/execjs-2.5.2/lib/execjs/runtimes.rb:48:in `autodetect': Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes. (ExecJS::RuntimeUnavailable)
```