### PR TITLE
Removed tilt warning messages on tests

### DIFF
--- a/test/integration/compilers_test.rb
+++ b/test/integration/compilers_test.rb
@@ -1,4 +1,6 @@
 require 'test_helper'
+require 'tilt/sass'
+require 'tilt/coffee'
 
 describe 'Compilers' do
   before do


### PR DESCRIPTION
This PR removes these warnings when running tests:

```
..................WARN: tilt autoloading 'tilt/coffee' in a non thread-safe way; explicit require 'tilt/coffee' suggested.
...WARN: tilt autoloading 'tilt/sass' in a non thread-safe way; explicit require 'tilt/sass' suggested.
```