### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ require 'lotus/assets'
 module Web
   module Views
     class ApplicationLayout
-      include Admin::Layout
+      include Web::Layout
       include Web::Assets::Helpers
     end
   end


### PR DESCRIPTION
Correct typo

I had to use `include Lotus::Assets::Helpers` instead of `include Web::Assets::Helpers` in my case. Not sure if this is a typo as well, or is simply not yet implemented.