### PR TITLE
Asset URL

### DIFF
--- a/lib/lotus/assets/helpers.rb
+++ b/lib/lotus/assets/helpers.rb
@@ -159,10 +159,11 @@ module Lotus
       end
 
       def asset_path(source)
-        _push_promise(
-          _absolute_url?(source) ?
-            source : _relative_path(source)
-        )
+        _asset_url(source) { _relative_url(source) }
+      end
+
+      def asset_url(source)
+        _asset_url(source) { _absolute_url(source) }
       end
 
       private
@@ -175,6 +176,13 @@ module Lotus
         )
       end
 
+      def _asset_url(source)
+        _push_promise(
+          _absolute_url?(source) ?
+            source : yield
+        )
+      end
+
       def _typed_asset_path(source, ext)
         source = "#{ source }#{ ext }" unless source.match(/#{ Regexp.escape(ext) }\z/)
         asset_path(source)
@@ -184,8 +192,12 @@ module Lotus
         URI.regexp.match(source)
       end
 
-      def _relative_path(source)
+      def _relative_url(source)
         self.class.assets_configuration.asset_path(source)
+      end
+
+      def _absolute_url(source)
+        self.class.assets_configuration.asset_url(source)
       end
 
       def _push_promise(url)

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -94,5 +94,22 @@ describe Lotus::Assets::Helpers do
       -> {view.video(content: true)}.must_raise ArgumentError
     end
   end
+
+  describe "#asset_path" do
+    it "returns relative URL for given asset name" do
+      result = view.asset_path('application.js')
+      result.must_equal '/assets/application.js'
+    end
+
+    it "returns absolute URL if the argument is an absolute URL" do
+      result = view.asset_path('http://assets.lotusrb.org/assets/application.css')
+      result.must_equal 'http://assets.lotusrb.org/assets/application.css'
+    end
+
+    it "adds source to HTTP/2 PUSH PROMISE list" do
+      view.asset_path('dashboard.js')
+      Thread.current[:__lotus_assets].must_include '/assets/application.js'
+    end
+  end
 end
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -108,7 +108,32 @@ describe Lotus::Assets::Helpers do
 
     it "adds source to HTTP/2 PUSH PROMISE list" do
       view.asset_path('dashboard.js')
-      Thread.current[:__lotus_assets].must_include '/assets/application.js'
+      Thread.current[:__lotus_assets].must_include '/assets/dashboard.js'
+    end
+  end
+
+  describe "#asset_url" do
+    before do
+      view.class.assets_configuration.load!
+    end
+
+    after do
+      view.class.assets_configuration.reset!
+    end
+
+    it "returns absolute URL for given asset name" do
+      result = view.asset_url('application.js')
+      result.must_equal('http://localhost:2300/assets/application.js')
+    end
+
+    it "returns absolute URL if the argument is an absolute URL" do
+      result = view.asset_url('http://assets.lotusrb.org/assets/application.css')
+      result.must_equal 'http://assets.lotusrb.org/assets/application.css'
+    end
+
+    it "adds source to HTTP/2 PUSH PROMISE list" do
+      view.asset_url('metrics.js')
+      Thread.current[:__lotus_assets].must_include 'http://localhost:2300/assets/metrics.js'
     end
   end
 end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1,97 +1,181 @@
 require 'test_helper'
 
 describe Lotus::Assets::Helpers do
+  let(:view)    { ImageHelperView.new({}, {}) }
+  let(:cdn_url) { 'https://bookshelf.cdn-example.com' }
 
-  def safe_string_class
-    ::Lotus::Utils::Escape::SafeString
+  after do
+    view.class.assets_configuration.reset!
   end
 
-  let(:view) { ImageHelperView.new({}, {}) }
-
   describe '#javascript' do
-    before do
-      @javascript = DefaultView.new.javascript('feature-a')
+    it 'returns an instance of SafeString' do
+      actual = DefaultView.new.javascript('feature-a')
+      actual.must_be_instance_of ::Lotus::Utils::Escape::SafeString
     end
 
-    it 'returns an instance of SafeString' do
-      @javascript.must_be_instance_of safe_string_class
+    it 'renders <script> tag' do
+      actual = DefaultView.new.javascript('feature-a')
+      actual.must_equal %(<script src="/assets/feature-a.js" type="text/javascript"></script>)
+    end
+
+    describe 'cdn mode' do
+      before do
+        activate_cdn_mode!
+      end
+
+      it 'returns absolute url for src attribute' do
+        actual = DefaultView.new.javascript('feature-a')
+        actual.must_equal %(<script src="#{ cdn_url }/assets/feature-a.js" type="text/javascript"></script>)
+      end
     end
   end
 
   describe '#stylesheet' do
-    before do
-      @stylesheet = DefaultView.new.stylesheet('main')
+    it 'returns an instance of SafeString' do
+      actual = DefaultView.new.stylesheet('main')
+      actual.must_be_instance_of ::Lotus::Utils::Escape::SafeString
     end
 
-    it 'returns an instance of SafeString' do
-      @stylesheet.must_be_instance_of safe_string_class
+    it 'renders <link> tag' do
+      actual = DefaultView.new.stylesheet('main')
+      actual.must_equal %(<link href="/assets/main.css" type="text/css" rel="stylesheet">)
+    end
+
+    describe 'cdn mode' do
+      before do
+        activate_cdn_mode!
+      end
+
+      it 'returns absolute url for href attribute' do
+        actual = DefaultView.new.stylesheet('main')
+        actual.must_equal %(<link href="#{ cdn_url }/assets/main.css" type="text/css" rel="stylesheet">)
+      end
     end
   end
 
   describe 'image' do
-    it 'render an img tag' do
-      view.image('application.jpg').to_s.must_equal %(<img src=\"/assets/application.jpg\" alt=\"Application\">)
+    it 'returns an instance of HtmlBuilder' do
+      actual = view.image('application.jpg')
+      actual.must_be_instance_of ::Lotus::Helpers::HtmlHelper::HtmlBuilder
+    end
+
+    it 'renders an <img> tag' do
+      actual = view.image('application.jpg').to_s
+      actual.must_equal %(<img src="/assets/application.jpg" alt="Application">)
     end
 
     it 'custom alt' do
-      view.image('application.jpg', alt: 'My Alt').to_s.must_equal %(<img alt=\"My Alt\" src=\"/assets/application.jpg\">)
+      actual = view.image('application.jpg', alt: 'My Alt').to_s
+      actual.must_equal %(<img alt="My Alt" src="/assets/application.jpg">)
     end
 
     it 'custom data attribute' do
-      view.image('application.jpg', 'data-user-id' => 5).to_s.must_equal %(<img data-user-id=\"5\" src=\"/assets/application.jpg\" alt=\"Application\">)
+      actual = view.image('application.jpg', 'data-user-id' => 5).to_s
+      actual.must_equal %(<img data-user-id="5" src="/assets/application.jpg" alt="Application">)
+    end
+
+    describe 'cdn mode' do
+      before do
+        activate_cdn_mode!
+      end
+
+      it 'returns absolute url for src attribute' do
+        actual = view.image('application.jpg').to_s
+        actual.must_equal %(<img src="#{ cdn_url }/assets/application.jpg" alt="Application">)
+      end
     end
   end
 
   describe '#favicon' do
-    it 'renders' do
-      view.favicon.to_s.must_equal %(<link href="/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">)
+    it 'returns an instance of HtmlBuilder' do
+      actual = view.favicon
+      actual.must_be_instance_of ::Lotus::Helpers::HtmlHelper::HtmlBuilder
+    end
+
+    it 'renders <link> tag' do
+      actual = view.favicon.to_s
+      actual.must_equal %(<link href="/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">)
     end
 
     it 'renders with HTML attributes' do
-      view.favicon('favicon.png', rel: 'icon', type: 'image/png').to_s.must_equal %(<link rel="icon" type="image/png" href="/assets/favicon.png">)
+      actual = view.favicon('favicon.png', rel: 'icon', type: 'image/png').to_s
+      actual.must_equal %(<link rel="icon" type="image/png" href="/assets/favicon.png">)
+    end
+
+    describe 'cdn mode' do
+      before do
+        activate_cdn_mode!
+      end
+
+      it 'returns absolute url for href attribute' do
+        actual = view.favicon.to_s
+        actual.must_equal %(<link href="#{ cdn_url }/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">)
+      end
     end
   end
 
   describe '#video' do
-    it 'renders' do
-      tag = view.video('movie.mp4')
-      tag.to_s.must_equal %(<video src="/assets/movie.mp4"></video>)
+    it 'returns an instance of HtmlBuilder' do
+      actual = view.video('movie.mp4')
+      actual.must_be_instance_of ::Lotus::Helpers::HtmlHelper::HtmlBuilder
+    end
+
+    it 'renders <video> tag' do
+      actual = view.video('movie.mp4').to_s
+      actual.must_equal %(<video src="/assets/movie.mp4"></video>)
     end
 
     it 'renders with html attributes' do
-      tag = view.video('movie.mp4', autoplay: true, controls: true)
-      tag.to_s.must_equal %(<video autoplay="autoplay" controls="controls" src="/assets/movie.mp4"></video>)
+      actual = view.video('movie.mp4', autoplay: true, controls: true).to_s
+      actual.must_equal %(<video autoplay="autoplay" controls="controls" src="/assets/movie.mp4"></video>)
     end
 
     it 'renders with fallback content' do
-      tag = view.video('movie.mp4') do
+      actual = view.video('movie.mp4') do
         "Your browser does not support the video tag"
-      end
-      tag.to_s.must_equal %(<video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>)
+      end.to_s
+
+      actual.must_equal %(<video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>)
     end
 
     it 'renders with tracks' do
-      tag = view.video('movie.mp4') do
+      actual = view.video('movie.mp4') do
         track kind: 'captions', src: view.asset_path('movie.en.vtt'), srclang: 'en', label: 'English'
-      end
-      tag.to_s.must_equal %(<video src="/assets/movie.mp4">\n<track kind="captions" src="/assets/movie.en.vtt" srclang="en" label="English">\n</video>)
+      end.to_s
+
+      actual.must_equal %(<video src="/assets/movie.mp4">\n<track kind="captions" src="/assets/movie.en.vtt" srclang="en" label="English">\n</video>)
     end
 
     it 'renders with sources' do
-      tag = view.video do
+      actual = view.video do
         text "Your browser does not support the video tag"
         source src: view.asset_path('movie.mp4'), type: 'video/mp4'
         source src: view.asset_path('movie.ogg'), type: 'video/ogg'
-      end
-      tag.to_s.must_equal %(<video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>)
+      end.to_s
+
+      actual.must_equal %(<video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>)
     end
 
     it 'raises an exception when no arguments' do
-      -> {view.video()}.must_raise ArgumentError
+      exception = -> { view.video() }.must_raise ArgumentError
+      exception.message.must_equal "You should provide a source via `src` option or with a `source` HTML tag"
     end
 
     it 'raises an exception when no src and no block' do
-      -> {view.video(content: true)}.must_raise ArgumentError
+      exception = -> { view.video(content: true) }.must_raise ArgumentError
+      exception.message.must_equal "You should provide a source via `src` option or with a `source` HTML tag"
+    end
+
+    describe 'cdn mode' do
+      before do
+        activate_cdn_mode!
+      end
+
+      it 'returns absolute url for src attribute' do
+        actual = view.video('movie.mp4').to_s
+        actual.must_equal %(<video src="#{ cdn_url }/assets/movie.mp4"></video>)
+      end
     end
   end
 
@@ -110,15 +194,22 @@ describe Lotus::Assets::Helpers do
       view.asset_path('dashboard.js')
       Thread.current[:__lotus_assets].must_include '/assets/dashboard.js'
     end
+
+    describe 'cdn mode' do
+      before do
+        activate_cdn_mode!
+      end
+
+      it 'returns absolute url' do
+        result = view.asset_path('application.js')
+        result.must_equal "https://bookshelf.cdn-example.com/assets/application.js"
+      end
+    end
   end
 
   describe "#asset_url" do
     before do
       view.class.assets_configuration.load!
-    end
-
-    after do
-      view.class.assets_configuration.reset!
     end
 
     it "returns absolute URL for given asset name" do
@@ -135,6 +226,28 @@ describe Lotus::Assets::Helpers do
       view.asset_url('metrics.js')
       Thread.current[:__lotus_assets].must_include 'http://localhost:2300/assets/metrics.js'
     end
+
+    describe 'cdn mode' do
+      before do
+        activate_cdn_mode!
+      end
+
+      it 'still returns absolute url' do
+        result = view.asset_url('application.js')
+        result.must_equal "https://bookshelf.cdn-example.com/assets/application.js"
+      end
+    end
+  end
+
+  private
+
+  def activate_cdn_mode!
+    view.class.assets_configuration.scheme 'https'
+    view.class.assets_configuration.host   'bookshelf.cdn-example.com'
+    view.class.assets_configuration.port   '443'
+    view.class.assets_configuration.cdn    true
+
+    view.class.assets_configuration.load!
   end
 end
 


### PR DESCRIPTION
## Asset URL

This PR introduces `asset_url` helper.

```erb
<%= asset_url 'logo.png' %>
```

```html
http://bookshelf.org/assets/logo.png
```

This is useful for rendering contexts where we need the full reference to an asset. An example is a mail message, where we need to use the absolute URL to assets.

### URL Configuration

This PR introduces three new settings in `Lotus::Assets::Configuration`:

  * `scheme`
  * `host`
  * `port`

They are used to compose the absolute URL

## CDN Mode

A new setting for `Lotus::Assets::Configuration` is introduced: `cdn`. It accepts a boolean. When `true`, all the asset helpers will use absolute URLs.

### Example in development mode (cdn is `false`):

```erb
<%= javascript 'greeting' %>
```

```html
<script src="/assets/greeting.js" type="text/javascript"></script>
```

### Example in development mode (cdn is `false`):

```erb
<%= javascript 'greeting' %>
```

```html
<script src="/assets/greeting-cd74d4a7721b32e364ea20f2035e86b4.js" type="text/javascript"></script>
```


### Example in production mode (cdn is `true`):

```erb
<%= javascript 'greeting' %>
```

```html
<script src="https://dc3vyqq4zav3s.cloudfront.net/assets/greeting-cd74d4a7721b32e364ea20f2035e86b4.js" type="text/javascript"></script>
```

/cc @lotus/core-team 