### PR TITLE
Skip compression of an asset in case of error during deploy

### DIFF
--- a/lib/lotus/assets/bundler.rb
+++ b/lib/lotus/assets/bundler.rb
@@ -117,6 +117,8 @@ module Lotus
       # @api private
       def _compress(compressor, asset)
         _write(asset, compressor.compress(::File.read(asset)))
+      rescue => e
+        warn "Skipping compression of: `#{ asset }'\n\nReason: #{ e }"
       end
 
       # @since x.x.x

--- a/test/bundler_test.rb
+++ b/test/bundler_test.rb
@@ -73,6 +73,16 @@ describe Lotus::Assets::Bundler do
     manifest.must_be :exist?
   end
 
+  describe "in case of error" do
+    let(:dest)   { TMP.join('broken', 'public') }
+    let(:source) { __dir__ + '/fixtures/broken/public/assets' }
+
+    it "prints the name of the asset that caused the problem" do
+      _, err = capture_subprocess_io { run! }
+      err.must_match "Skipping compression of:"
+    end
+  end
+
   private
 
   def run!

--- a/test/fixtures/broken/public/assets/broken.js
+++ b/test/fixtures/broken/public/assets/broken.js
@@ -1,0 +1,1 @@
+// This empty JavaScript causes an error with YUICompressor


### PR DESCRIPTION
YUI-Compressor complains too much.

Because compression isn't a crucial step for deployments, we print a warning and let developers to still deploy and review later the reason of the problem.

**The asset will remain uncompressed in the destination directory (`public/assets`).**

Browsers will still be able to download and use that asset. The transfer will be less efficient because it's not compressed. This trade off is way better that stopping the deploy.

---

This is an example of output (on `stderr`) that Lotus will print in case of error:

```shell
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.yahoo.platform.yui.compressor.Bootstrap.main(Bootstrap.java:21)
Caused by: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
	at java.util.ArrayList.get(ArrayList.java:429)
	at com.yahoo.platform.yui.compressor.JavaScriptCompressor.getToken(JavaScriptCompressor.java:578)
	at com.yahoo.platform.yui.compressor.JavaScriptCompressor.printSymbolTree(JavaScriptCompressor.java:1094)
	at com.yahoo.platform.yui.compressor.JavaScriptCompressor.compress(JavaScriptCompressor.java:556)
	at com.yahoo.platform.yui.compressor.YUICompressor.main(YUICompressor.java:186)
	... 5 more
Skipping compression of: `/Users/luca/Code/lotus/assets/tmp/broken/public/assets/broken.js'
Reason: Command 'java -jar /Users/luca/.gem/ruby/2.3.0/gems/yui-compressor-0.12.0/lib/yui/../yuicompressor-2.4.8.jar --type js --charset utf-8 /var/folders/rt/276jdh_d1cs8gsfws5_7f7600000gn/T/yui_compress20160104-46561-177aftt' returned non-zero exit status
	/Users/luca/.gem/ruby/2.3.0/gems/yui-compressor-0.12.0/lib/yui/compressor.rb:106:in `block in compress'
	/Users/luca/.gem/ruby/2.3.0/gems/yui-compressor-0.12.0/lib/yui/compressor.rb:141:in `streamify'
	/Users/luca/.gem/ruby/2.3.0/gems/yui-compressor-0.12.0/lib/yui/compressor.rb:86:in `compress'
	/Users/luca/Code/lotus/assets/lib/lotus/assets/bundler.rb:119:in `_compress'
	/Users/luca/Code/lotus/assets/lib/lotus/assets/bundler.rb:85:in `compress'
	/Users/luca/Code/lotus/assets/lib/lotus/assets/bundler.rb:66:in `block in run'
	/Users/luca/Code/lotus/assets/lib/lotus/assets/bundler.rb:63:in `each'
	/Users/luca/Code/lotus/assets/lib/lotus/assets/bundler.rb:63:in `run'
	test/bundler_test.rb:90:in `run!'
	test/bundler_test.rb:81:in `block (3 levels) in <main>'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest/test.rb:108:in `block (3 levels) in run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest/test.rb:205:in `capture_exceptions'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest/test.rb:105:in `block (2 levels) in run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest/test.rb:256:in `time_it'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest/test.rb:104:in `block in run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:334:in `on_signal'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest/test.rb:276:in `with_info_handler'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest/test.rb:103:in `run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:781:in `run_one_method'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:308:in `run_one_method'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:296:in `block (2 levels) in run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:295:in `each'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:295:in `block in run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:334:in `on_signal'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:321:in `with_info_handler'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:294:in `run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:155:in `block in __run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:155:in `map'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:155:in `__run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:129:in `run'
	/Users/luca/.rubies/ruby-2.3.0/lib/ruby/gems/2.3.0/gems/minitest-5.8.3/lib/minitest.rb:56:in `block in autorun'
```

---

/cc @lotus/core-team 